### PR TITLE
#![feature(clamp)] for E0658

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(clamp)]
+
 mod qmath;
 mod pattern_along_path;
 mod glifwriter;


### PR DESCRIPTION
```
error[E0658]: use of unstable library feature 'clamp'
   --> src/qmath/mod.rs:357:17
    |
357 |         let u = f64::clamp(_u, 0., 1.);
    |                 ^^^^^^^^^^
    |
    = note: see issue #44095 <https://github.com/rust-lang/rust/issues/44095> for more information
    = help: add `#![feature(clamp)]` to the crate attributes to enable

error: aborting due to previous error

```